### PR TITLE
Use ENV['HOME'] instead of hardcoding home dir

### DIFF
--- a/spec/trash_spec.rb
+++ b/spec/trash_spec.rb
@@ -55,28 +55,28 @@ describe "Trash" do
     Trash.new.throw_out("/tmp/testing.txt")
     tmp_should_not_contain "testing.txt"
     trash_should_contain "testing.txt"
-    original = File.new("/Users/leejones/.Trash/testing.txt", "r")
+    original = File.new("#{ENV['HOME']}/.Trash/testing.txt", "r")
     original.read.should == "default text\n"
     
     `echo 'testing different file with same name' > /tmp/testing.txt`
     Trash.new.throw_out("/tmp/testing.txt")
     tmp_should_not_contain "testing.txt"
     trash_should_contain "testing01.txt" 
-    third = File.new("/Users/leejones/.Trash/testing01.txt", "r")
+    third = File.new("#{ENV['HOME']}/.Trash/testing01.txt", "r")
     third.read.should == "testing different file with same name\n"
   
     `echo 'testing different file 2 with same name' > /tmp/testing.txt`
     Trash.new.throw_out("/tmp/testing.txt")
     tmp_should_not_contain "testing.txt"
     trash_should_contain "testing02.txt"
-    fourth = File.new("/Users/leejones/.Trash/testing02.txt", "r")
+    fourth = File.new("#{ENV['HOME']}/.Trash/testing02.txt", "r")
     fourth.read.should == "testing different file 2 with same name\n"
 
     `echo 'testing different file 3 with same name' > /tmp/testing.txt`
     Trash.new.throw_out("/tmp/testing.txt")
     tmp_should_not_contain "testing.txt"
     trash_should_contain "testing03.txt"
-    fifth = File.new("/Users/leejones/.Trash/testing03.txt", "r")
+    fifth = File.new("#{ENV['HOME']}/.Trash/testing03.txt", "r")
     fifth.read.should == "testing different file 3 with same name\n"
     
     delete_from_trash "testing.txt"


### PR DESCRIPTION
There were some hardcoded paths that were causing the tests to fail for me. I presume they were not failing for you because they are specific to your home directory. I replaced those paths with `ENV['HOME']` but in the future after we get the tests updated perhaps we will want to replace this with the Ruby 1.9/2.0 method `Dir.home` instead.

Information hiding FTW!
