### PR TITLE
Fix filename number append bug

### DIFF
--- a/lib/trash.rb
+++ b/lib/trash.rb
@@ -47,7 +47,7 @@ class Trash
     if File.directory? path
       unique_file_name_finder { |c| "#{file_name}#{"%02d" % c}" }
     else
-      unique_file_name_finder { |c| "#{file_name.gsub(file_extension, "#{"%02d" % c}#{file_extension}")}" }
+      unique_file_name_finder { |c| file_name.gsub(file_extension, "#{"%02d" % c}#{file_extension}") }
     end
   end
   

--- a/lib/trash.rb
+++ b/lib/trash.rb
@@ -41,13 +41,14 @@ class Trash
   def unique_file_name(path)
     file_name      = File.basename(path)
     file_extension = File.extname(path)
+    file_name_without_extension = File.basename(path, ".*")
 
     return file_name unless File.exists?("#{@trash_can}/#{file_name}")
 
     if File.directory? path
       unique_file_name_finder { |c| "#{file_name}#{"%02d" % c}" }
     else
-      unique_file_name_finder { |c| file_name.gsub(file_extension, "#{"%02d" % c}#{file_extension}") }
+      unique_file_name_finder { |c| "#{file_name_without_extension}#{"%02d" % c}#{file_extension}" }
     end
   end
   

--- a/spec/trash_spec.rb
+++ b/spec/trash_spec.rb
@@ -89,6 +89,23 @@ describe "Trash" do
     delete_from_trash "testing03.txt"
   end
   
+  it 'appends a number to duplicate filename even when it has no extension' do
+    text1 = "text content"
+    text2 = "different content"
+    `echo '#{text1}' > /tmp/testing`
+    Trash.new.throw_out("/tmp/testing")
+    `echo '#{text2}' > /tmp/testing`
+    Trash.new.throw_out("/tmp/testing")
+
+    trash_should_contain "testing"
+    File.read("#{trash_dir}/testing").should == "#{text1}\n"
+    trash_should_contain "testing01"
+    File.read("#{trash_dir}/testing01").should == "#{text2}\n"
+
+    delete_from_trash "testing"
+    delete_from_trash "testing01"
+  end
+
   it "should throw an error when file does not exist" do
     tmp_should_not_contain "not_a_file.txt"
     trash = Trash.new


### PR DESCRIPTION
This fixes a bug that causes duplicate filenames to be assigned strange names when trashed. For example:

```
touch foobar
trash foobar
touch foobar
trash foobar
```

renames the second `foobar` file to `01f01o01o01b01a01r01` when it's also trashed. This is because gsub is searching for an empty string (the nonexistent file extension) and apparently replacing the empty strings results in placing the replacement string (our two digit number) between every character. Hence the strange file name.

I would expect a duplicate filename without an extension to simply have a number appended to the end of its name when trashed. So that's the behavior I've implemented in this pull request.