### PR TITLE
Update development dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,5 @@ tmtags
 coverage
 rdoc
 pkg
-Gemfile.lock
 
 ## PROJECT::SPECIFIC

--- a/Gemfile
+++ b/Gemfile
@@ -6,8 +6,8 @@ source "https://rubygems.org"
 # Add dependencies to develop your gem here.
 # Include everything needed to run rake, tests, features, etc.
 group :development do
-  gem "jeweler", "~> 2.3.3"
-  gem "rspec", "~> 2.14.1"
-  gem "rake", "~> 10.1.0"
-  gem "rdoc", "~> 4.0.1"
+  gem "jeweler", "~> 2.3.9"
+  gem "rspec", "~> 3.12.0"
+  gem "rake", "~> 13.0.6"
+  gem "rdoc", "~> 6.5.0"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,83 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.4.0)
+    builder (3.2.4)
+    descendants_tracker (0.0.4)
+      thread_safe (~> 0.3, >= 0.3.1)
+    diff-lcs (1.5.0)
+    faraday (0.9.2)
+      multipart-post (>= 1.2, < 3)
+    git (1.11.0)
+      rchardet (~> 1.8)
+    github_api (0.16.0)
+      addressable (~> 2.4.0)
+      descendants_tracker (~> 0.0.4)
+      faraday (~> 0.8, < 0.10)
+      hashie (>= 3.4)
+      mime-types (>= 1.16, < 3.0)
+      oauth2 (~> 1.0)
+    hashie (5.0.0)
+    highline (2.1.0)
+    jeweler (2.3.9)
+      builder
+      bundler
+      git (>= 1.2.5)
+      github_api (~> 0.16.0)
+      highline (>= 1.6.15)
+      nokogiri (>= 1.5.10)
+      psych
+      rake
+      rdoc
+      semver2
+    jwt (2.7.1)
+    mime-types (2.99.3)
+    mini_portile2 (2.8.4)
+    multi_json (1.15.0)
+    multi_xml (0.6.0)
+    multipart-post (2.3.0)
+    nokogiri (1.13.10)
+      mini_portile2 (~> 2.8.0)
+      racc (~> 1.4)
+    oauth2 (1.4.8)
+      faraday (>= 0.8, < 3.0)
+      jwt (>= 1.0, < 3.0)
+      multi_json (~> 1.3)
+      multi_xml (~> 0.5)
+      rack (>= 1.2, < 3)
+    psych (5.1.0)
+      stringio
+    racc (1.7.1)
+    rack (2.2.8)
+    rake (13.0.6)
+    rchardet (1.8.0)
+    rdoc (6.5.0)
+      psych (>= 4.0.0)
+    rspec (3.12.0)
+      rspec-core (~> 3.12.0)
+      rspec-expectations (~> 3.12.0)
+      rspec-mocks (~> 3.12.0)
+    rspec-core (3.12.2)
+      rspec-support (~> 3.12.0)
+    rspec-expectations (3.12.3)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.12.0)
+    rspec-mocks (3.12.6)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.12.0)
+    rspec-support (3.12.1)
+    semver2 (3.4.2)
+    stringio (3.0.6)
+    thread_safe (0.3.6)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  jeweler (~> 2.3.9)
+  rake (~> 13.0.6)
+  rdoc (~> 6.5.0)
+  rspec (~> 3.12.0)
+
+BUNDLED WITH
+   1.17.2


### PR DESCRIPTION
Updated all development dependencies to their latest versions.

Closes https://github.com/leejones/trash/security/dependabot/5
Closes https://github.com/leejones/trash/security/dependabot/4